### PR TITLE
feat: include `base_coin/base_coin` pairs

### DIFF
--- a/src/rates/merger/index.ts
+++ b/src/rates/merger/index.ts
@@ -130,14 +130,18 @@ export abstract class RatesMerger {
         return;
       }
 
-      enabledCoins.forEach((coin) => {
-        const priceAlt = 1 / tickers[`${coin}/USD`];
-
-        if (!priceAlt) {
+      [...this.baseCoins, ...enabledCoins].forEach((coin) => {
+        if (tickers[`${coin}/${baseCoin}`]) {
           return;
         }
 
-        tickers[`${coin}/${baseCoin}`] = +(price / priceAlt).toFixed(decimals);
+        const coinPrice = tickers[`${coin}/USD`];
+
+        if (!coinPrice) {
+          return;
+        }
+
+        tickers[`${coin}/${baseCoin}`] = +(price * coinPrice).toFixed(decimals);
       });
     });
 


### PR DESCRIPTION
e.g. for
```json5
{ // config.json
  "base_coins": ["USD", "RUB"],
}
```

the API will now return:

```json5
{
  // ...
  "result": {
    "USD/RUB": 89.06400000225,
    "RUB/RUB": 1,
    // ...
  }
}
```
