### PR TITLE
`/status` endpoint

### DIFF
--- a/src/rates/rates.controller.ts
+++ b/src/rates/rates.controller.ts
@@ -41,7 +41,15 @@ export class RatesController {
 
   @Get('status')
   getStatus() {
-    const ready = this.ratesService.lastUpdated !== 0;
-    return { ready };
+    const { lastUpdated, refreshInterval, initializationTimestamp } =
+      this.ratesService;
+
+    const ready = lastUpdated !== 0;
+    const next_update = ready
+      ? lastUpdated + refreshInterval
+      : initializationTimestamp;
+    const updating = next_update < Date.now();
+
+    return { ready, updating, next_update };
   }
 }

--- a/src/rates/rates.interceptor.ts
+++ b/src/rates/rates.interceptor.ts
@@ -24,9 +24,9 @@ export class RatesInterceptor implements NestInterceptor {
         return {
           success: true,
           date: Date.now(),
+          ...data,
           last_updated: lastUpdated || null,
           version,
-          ...data,
         };
       }),
     );


### PR DESCRIPTION
Not initialized (`/get` endpoint doesn't include any rates):
```json5
{
  "success": true,
  "date": 1720929107999,
  "ready": false, // this is `false`
  "updating": true,
  "next_update": 1720929107763, // time of the app start
  "last_updated": null, // this is `null`
  "version": "4.0.0"
}
```

Initialized:
```json5
{
  "success": true,
  "date": 1720928929287,
  "ready": true, // this is `true`
  "updating": false,
  "next_update": 1720929503829,
  "last_updated": 1720928903829, // this includes timestamp
  "version": "4.0.0"
}
```

Updating rates:
```json5
{
  "success": true,
  "date": 1720929504829,
  "ready": true,
  "updating": true, // this is `true`
  "next_update": 1720929503829, // next_update < date
  "last_updated": 1720928903829,
  "version": "4.0.0"
}
```