### PR TITLE
feat(config): add option to choose database

### DIFF
--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -29,7 +29,8 @@
     "port": 36661, // Port number for the API service, e.g., http://localhost:36661
     "mongodb": {
       "host": "mongodb",
-      "port": 27017
+      "port": 27017,
+      "db": "tickersdb"
     }
   },
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,8 +12,6 @@ import { LoggerModule } from './global/logger/logger.module';
 import { NotifierModule } from './global/notifier/notifier.module';
 import { Logger } from './global/logger/logger.service';
 
-const MONGODB_NAME = 'tickersdb';
-
 @Module({
   imports: [
     ScheduleModule.forRoot(),
@@ -30,15 +28,16 @@ const MONGODB_NAME = 'tickersdb';
       useFactory: (config: ConfigService, logger: Logger) => {
         const port = config.get('server.mongodb.port');
         const host = config.get('server.mongodb.host');
+        const db = config.get('server.mongodb.db');
 
         return {
-          uri: `mongodb://${host}:${port}/${MONGODB_NAME}`,
+          uri: `mongodb://${host}:${port}/${db}`,
           retryAttempts: 0,
           serverSelectionTimeoutMS: 1000,
           connectionFactory(connection) {
             connection.on('connected', () => {
               logger.log(
-                `InfoService successfully connected to '${MONGODB_NAME}' MongoDB.`,
+                `InfoService successfully connected to '${db}' MongoDB.`,
               );
             });
             connection._events.connected();

--- a/src/global/config/schema.ts
+++ b/src/global/config/schema.ts
@@ -48,6 +48,7 @@ export const schema = z
       mongodb: z.object({
         port: z.number(),
         host: z.string(),
+        db: z.string(),
       }),
     }),
 


### PR DESCRIPTION
```jsonc
{ // config.jsonc

  "server": {
    "port": 36661,
    "mongodb": {
      "host": "mongodb",
      "port": 27017,
      "db": "tickersdb" // <----------
    }
  }

}
```