### PR TITLE
fix: save rates for valid pairs

### DIFF
--- a/src/rates/rates.service.ts
+++ b/src/rates/rates.service.ts
@@ -229,7 +229,7 @@ export class RatesService extends RatesMerger {
         .map((pair, error) => `${pair}: ${error}`)
         .join('\n');
 
-      return this.fail(`The rates won't be saved:\n${error}`);
+      this.fail(`The rates won't be saved for the following pairs:\n${error}`);
     }
 
     try {


### PR DESCRIPTION
**Before**

The rates are not saved if one of the pairs failed
![image](https://github.com/user-attachments/assets/f56e7e03-acdf-41a9-b538-2db7f13b6119)

**After**

The rates that are passed the check will be saved 