### PR TITLE
feat: add `name` to the config for notifications

### DIFF
--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -1,4 +1,6 @@
 {
+  "name": "Currencyinfo", // Name of the Currencyinfo instance that will be used for notifications (optional)
+
   "decimals": 12, // Number of decimal places for rate values
 
   // Read Dealing with Rate Differences from Multiple Sources

--- a/src/global/config/schema.ts
+++ b/src/global/config/schema.ts
@@ -29,6 +29,8 @@ const apiSourceSchema = z.object({
 
 export const schema = z
   .object({
+    name: z.string().default('Currencyinfo'),
+
     decimals: z.number().default(12),
 
     strategy: z.enum(['avg', 'min', 'max', 'priority', 'weight']),

--- a/src/global/notifier/notifier.service.ts
+++ b/src/global/notifier/notifier.service.ts
@@ -41,9 +41,13 @@ export class Notifier {
       return;
     }
 
-    this.notifySlack(notifyLevel, message);
-    this.notifyDiscord(notifyLevel, message);
-    this.notifyAdamant(notifyLevel, message);
+    const name = this.config.get('name') as string;
+
+    const notifyMessage = `**${name}**# ${message}`;
+
+    this.notifySlack(notifyLevel, notifyMessage);
+    this.notifyDiscord(notifyLevel, notifyMessage);
+    this.notifyAdamant(notifyLevel, notifyMessage);
   }
 
   async notifySlack(notifyLevel: LogLevelName, message: string) {


### PR DESCRIPTION
From `config.default.jsonc`:
```jsonc
{
  "name": "Currencyinfo", // Name of the Currencyinfo instance that will be used for notifications (optional)
}
```

Example:

![image](https://github.com/user-attachments/assets/c27b0ca8-cea8-471e-9ce2-648951044af3)
