### PR TITLE
feat: add `mappings` in the config

### DIFF
--- a/config.default.jsonc
+++ b/config.default.jsonc
@@ -59,6 +59,11 @@
   // List of base coins for calculating all available pairs
   "base_coins": ["USD", "RUB", "EUR", "CNY", "JPY", "BTC", "ETH"],
 
+  // A mapping of symbols to their standardized names for consistency across different sources
+  "mappings": {
+    "CWIF": "$CWIF"
+  },
+
   // Free Moscow Exchange (https://moex.com) API configuration. Fiat currencies mostly.
   // Using a Russian proxy server because MOEX may block requests from hostile countries. The proxy updates data every 3 minutes.
   // The direct source link is https://iss.moex.com/iss/engines/currency/markets/selt/securities.jsonp

--- a/src/global/config/schema.ts
+++ b/src/global/config/schema.ts
@@ -67,6 +67,7 @@ export const schema = z
     log_level: z.enum(['none', 'log', 'warn', 'error']).default('log'),
 
     base_coins: z.array(coinName),
+    mappings: z.record(z.string()).optional(),
 
     // API
     moex: apiSourceSchema

--- a/src/rates/rates.service.ts
+++ b/src/rates/rates.service.ts
@@ -212,7 +212,9 @@ export class RatesService extends RatesMerger {
         continue;
       }
 
-      this.mergeTickers(tickers, { name: source.resourceName });
+      this.mergeTickers(this.applyMappings(tickers), {
+        name: source.resourceName,
+      });
 
       availableSources += 1;
     }
@@ -465,6 +467,27 @@ export class RatesService extends RatesMerger {
         tickers,
       });
     }
+  }
+
+  applyMappings(tickers: Tickers) {
+    const mappings = this.config.get('mappings') as Record<string, string>;
+
+    if (!mappings) {
+      return tickers;
+    }
+
+    for (const [pair, price] of Object.entries(tickers)) {
+      let [quote, base] = pair.split('/');
+
+      quote = mappings[quote] || quote;
+      base = mappings[base] || base;
+
+      delete tickers[pair];
+
+      tickers[`${quote}/${base}`] = price;
+    }
+
+    return tickers;
   }
 
   fail(reason: string) {


### PR DESCRIPTION
Added global mappings that replace the symbol names 

```jsonc
// A mapping of symbols to their standardized names for consistency across different sources
"mappings": {
  "CWIF": "$CWIF"
},
```