### PR TITLE
feat: rub as the base for moex

### DIFF
--- a/src/rates/api/moex.ts
+++ b/src/rates/api/moex.ts
@@ -80,13 +80,6 @@ export class MoexApi extends BaseApi {
 
     const basePrice = this.getPrice('USD/RUB', data)!;
 
-    if (!basePrice) {
-      this.notifier.notify(
-        'error',
-        `Unable to get all of MOEX rates: No base price for USD/RUB has been found. Ensure config has the code for the pair.`,
-      );
-    }
-
     for (const pair of Object.keys(this.codes)) {
       let price = this.getPrice(pair, data);
 
@@ -98,15 +91,19 @@ export class MoexApi extends BaseApi {
         price /= 100;
       }
 
-      if (pair === 'USD/RUB') {
-        rates['RUB/USD'] = Number((1 / basePrice).toFixed(decimals));
+      if (basePrice) {
+        if (pair === 'USD/RUB') {
+          rates['RUB/USD'] = Number((1 / basePrice).toFixed(decimals));
+        } else {
+          rates[pair] = Number(price.toFixed(decimals));
+
+          const market = `${pair.replace('/RUB', '')}/USD`;
+          const altPrice = rates[pair] / basePrice;
+
+          rates[market] = Number(altPrice.toFixed(decimals));
+        }
       } else {
-        rates[pair] = Number(price.toFixed(decimals));
-
-        const market = `${pair.replace('/RUB', '')}/USD`;
-        const altPrice = rates[pair] / basePrice;
-
-        rates[market] = Number(altPrice.toFixed(decimals));
+        rates[pair] = price;
       }
     }
 

--- a/src/rates/api/moex.ts
+++ b/src/rates/api/moex.ts
@@ -91,19 +91,17 @@ export class MoexApi extends BaseApi {
         price /= 100;
       }
 
-      if (basePrice) {
-        if (pair === 'USD/RUB') {
-          rates['RUB/USD'] = Number((1 / basePrice).toFixed(decimals));
-        } else {
-          rates[pair] = Number(price.toFixed(decimals));
+      if (pair === 'USD/RUB') {
+        rates['RUB/USD'] = Number((1 / basePrice).toFixed(decimals));
+      } else {
+        rates[pair] = Number(price.toFixed(decimals));
 
+        if (basePrice) {
           const market = `${pair.replace('/RUB', '')}/USD`;
           const altPrice = rates[pair] / basePrice;
 
           rates[market] = Number(altPrice.toFixed(decimals));
         }
-      } else {
-        rates[pair] = price;
       }
     }
 


### PR DESCRIPTION
Since MOEX ([Moscow Exchange](https://www.moex.com/en)) no longer supports `USD/RUB` pair due to sanctions, you can remove `USD/RUB` from the `moex.codes` in the config to use `RUB` as the only base coin for the pairs fetched from MOEX (Note that you don't have to add `RUB` in the `base_coins`)

## Before
```jsonc
{ // config.jsonc
  "base_coins": ["USD"],
  "moex": {
    "enabled": true,
    "url": "...",
    "codes": {
      "USD/RUB": "USDRUB_TOM",
      "EUR/RUB": "EURRUB_TOM",
      "CNY/RUB": "CNYRUB_TOM"
    }
  },
}
```

`/get` endpoint response:

```jsonc
{
  "success": true,
  "date": 1724242799046,
  "result": {
    "RUB/USD": 0.011227881074,
    "EUR/RUB": 95.66535,
    "EUR/USD": 1.07411917273,
    "CNY/RUB": 12.15545,
    "CNY/USD": 0.136479947004
  },
  "last_updated": 1724242686734,
  "version": "4.1.0"
}
```

## After

```jsonc
{ // config.jsonc
  "base_coins": ["USD"],
  "moex": {
    "enabled": true,
    "url": "https://rusdoor.adamant.im/securities.jsonp",
    "codes": {
      "CNY/RUB": "CNYRUB_TOM"
    }
  },
}
```

`/get` endpoint response:

```jsonc
{
  "success": true,
  "date": 1724242927703,
  "result": {
    "CNY/RUB": 12.15545
  },
  "last_updated": 1724242868591,
  "version": "4.0.0"
}
```